### PR TITLE
Add a new account constructor for an existing private key

### DIFF
--- a/account.go
+++ b/account.go
@@ -25,6 +25,10 @@ func NewAccount() *Account {
 	return &Account{k}
 }
 
+func NewAccountFromPrivKey(pk *ecdsa.PrivateKey) *Account {
+	return &Account{pk}
+}
+
 type Account struct {
 	pk *ecdsa.PrivateKey
 }


### PR DESCRIPTION
This allows the creation of an Ethertest account from an existing private key instead of the randomly generated one.